### PR TITLE
systemd socket activation: fix socket protocol

### DIFF
--- a/systemd/triggerhappy.socket
+++ b/systemd/triggerhappy.socket
@@ -1,5 +1,5 @@
 [Socket]
-ListenStream=/run/thd.socket
+ListenDatagram=/run/thd.socket
 
 [Install]
 WantedBy=sockets.target


### PR DESCRIPTION
Without the following correction, attempts to interact with th-cmd --socket /run/thd.socket give an error, about the protocol being the wrong type for the socket.

triggerhappy uses a datagram type socket, thus the one line fix in the socket activation file.
