### PR TITLE
Specified user in daemon config is not respected.

### DIFF
--- a/systemd/triggerhappy.service
+++ b/systemd/triggerhappy.service
@@ -4,7 +4,7 @@ After=local-fs.target
 
 [Service]
 Type=notify
-ExecStart=/usr/sbin/thd --triggers /etc/triggerhappy/triggers.d/ --socket /run/thd.socket --user nobody --deviceglob /dev/input/event*
+ExecStart=/usr/sbin/thd --triggers /etc/triggerhappy/triggers.d/ --socket /run/thd.socket --deviceglob /dev/input/event*
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Daemon user options passed in file `/etc/default/triggerhappy` are not respected due to hardcoded `nobody` user in `triggerhappy.service` service config file.