### PR TITLE
added support for pure REL/ABS devices (such as rotary encoders)

### DIFF
--- a/devices.c
+++ b/devices.c
@@ -45,7 +45,8 @@ int device_is_suitable(int fd) {
 	int rc = ioctl(fd, EVIOCGBIT(0,sizeof(bits)), bits);
 	return rc > 0 && (
 		/* we only consider devices with keys or switches suitable */
-		test_bit(EV_KEY, bits) || test_bit(EV_SW, bits)
+		test_bit(EV_KEY, bits) || test_bit(EV_SW, bits) ||
+		test_bit(EV_REL, bits) || test_bit(EV_ABS, bits)
 	);
 }
 


### PR DESCRIPTION
some input devices such as rotary encoders don't have keys or switches, but can generate EV_REL/EV_ABS events. this simple change allows these devices to be used with triggerhappy. I checked with my two rotary encoders and it works. thanks!
