### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: triggerhappy
 Section: utils
 Priority: extra
 Maintainer: Stefan Tomanek <stefan.tomanek+debian@wertarbyte.de>
-Build-Depends: debhelper (>= 9), linux-libc-dev, pkg-config, libsystemd-dev, dh-systemd
+Build-Depends: debhelper (>= 9), linux-libc-dev, pkg-config, libsystemd-dev, debhelper (>= 9.20160709)
 Standards-Version: 3.9.8
 Homepage: https://github.com/wertarbyte/triggerhappy
 Vcs-Git: https://github.com/wertarbyte/triggerhappy.git

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: triggerhappy
 Section: utils
 Priority: extra
 Maintainer: Stefan Tomanek <stefan.tomanek+debian@wertarbyte.de>
-Build-Depends: debhelper (>= 9), linux-libc-dev, pkg-config, libsystemd-dev, dh-systemd (>= 1.5)
+Build-Depends: debhelper (>= 9), linux-libc-dev, pkg-config, libsystemd-dev, dh-systemd
 Standards-Version: 3.9.8
 Homepage: https://github.com/wertarbyte/triggerhappy
 Vcs-Git: https://github.com/wertarbyte/triggerhappy.git


### PR DESCRIPTION
Remove unnecessary constraints.

## Debdiff

These changes affect the binary packages:

[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/27/97cfc3f023cd26a9eadd7f42cd1a44e12b24f0.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/ef/b7ec86fddd29a0daadd37e0a1d40e8ccf985f0.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/13/cc4afe2fc8b9d0f47819edac0f74ff817facbe.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/ec/5f538b43969c25060925b4a7496087808e6359.debug

No differences were encountered between the control files of package \*\*triggerhappy\*\*
### Control files of package triggerhappy-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-13cc4afe2fc8b9d0f47819edac0f74ff817facbe ec5f538b43969c25060925b4a7496087808e6359-] {+2797cfc3f023cd26a9eadd7f42cd1a44e12b24f0 efb7ec86fddd29a0daadd37e0a1d40e8ccf985f0+}

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/f2eb5a6e-4930-485a-ad75-112b6c5a690e/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/f2eb5a6e-4930-485a-ad75-112b6c5a690e/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/scrub-obsolete), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/scrub-obsolete/pkg/triggerhappy/f2eb5a6e-4930-485a-ad75-112b6c5a690e.